### PR TITLE
allow to disable notification for certain topics

### DIFF
--- a/powerlibs/django/contrib/notifiers/models.py
+++ b/powerlibs/django/contrib/notifiers/models.py
@@ -78,8 +78,9 @@ class ChangeNotifierMixin(NotifierMixin):
                 safe_value = self.get_safe_value_for_status_notification(new_value)
                 topic_name = self.get_topic_name_for_status_notification(field_name, safe_value)
 
-                message = self.serialize()
-                message['_old_value'] = old_value
-                message['_changed_field'] = field_name
+                if topic_name:
+                    message = self.serialize()
+                    message['_old_value'] = old_value
+                    message['_changed_field'] = field_name
 
-                self.notify(topic_name, message)
+                    self.notify(topic_name, message)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-version = '0.0.1'
+version = '0.0.2'
 
 
 def pip_git_to_setuptools_git(url):

--- a/tests/test_change_notifier.py
+++ b/tests/test_change_notifier.py
@@ -1,3 +1,4 @@
+from unittest import mock
 import pytest
 
 
@@ -55,12 +56,26 @@ def test_ChangeNotifierModel_activation_change(mocked_notifier, change_notifier_
     assert data['_old_value'] == old_value
 
 
+def test_ChangeNotifierModel_activation_change_when_notification_for_topic_is_canceled(mocked_notifier, change_notifier_model):
+    # Create:
+    instance = change_notifier_model(name='test changing activation data')
+    instance.get_topic_name_for_status_notification = mock.Mock(return_value=None)
+    instance.save()
+
+    assert mocked_notifier.notify.call_count == 0
+
+    # Update:
+    instance.activated = True
+    instance.save()
+
+    assert mocked_notifier.notify.call_count == 0
+
+
 def test_change_notifier_with_blank_value(mocked_notifier, change_notifier_model):
     blank_instance = change_notifier_model(name='', status='')
     blank_instance.save()
 
     topics = tuple(args[0] for args, kwargs in mocked_notifier.notify.call_args_list)
-    print('topics:', topics)
     assert 'change_notifier_model__blank' in topics
 
     """


### PR DESCRIPTION
Example: when we have `step_name` and `step_status` and use `get_topic_name_for_status_notification` to generate an unified topic name. We will send the message only on one of the changes (`step_status`, probably), not both, so we need to cancel the second one.